### PR TITLE
Fix mailmap for users with different emails! 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Jonatan Almén <joalmen@student.chalmers.se> <j_almen@hotmail.com>
+Adam Ingmansson <adam.ingmansson@gmail.com> <adam.ingmansson@gmail.com>
+Axel Olivecrona <axel.olivecrona1995@gmail.com>
+Mikael Kajsjö <mkajsjo2@gmail.com>


### PR DESCRIPTION
previously users was displayed in multiple lines only differing on the email in `git shortlog -sne` 
.mailmap solves this by aggregating everyone with the same email address to one 
commonly used.
